### PR TITLE
Add GOES-18 Utah satellite imagery example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -4,8 +4,37 @@ This folder contains end-to-end example applications demonstrating NDP-EP capabi
 
 ## Contents
 
-*No examples yet*
+| Example | Description |
+|---------|-------------|
+| [GOES-18 Utah Satellite](./goes-utah-satellite.ipynb) | Process GOES-18 satellite imagery for Utah region with interactive Folium visualization |
+
+## Running Examples
+
+### Google Colab
+
+Most notebooks include an "Open in Colab" badge at the top. Click it to run the notebook directly in Google Colab without local setup.
+
+### Local Execution
+
+1. Create a virtual environment:
+   ```bash
+   python3 -m venv .venv
+   source .venv/bin/activate
+   ```
+
+2. Install dependencies:
+   ```bash
+   pip install ndp-ep xarray netCDF4 pyproj folium numpy requests pillow
+   ```
+
+3. Open Jupyter:
+   ```bash
+   pip install jupyter
+   jupyter notebook
+   ```
 
 ## Prerequisites
 
-Each example includes its own requirements and setup instructions.
+- Access to an NDP-EP API instance
+- Valid authentication token
+- See each example for specific requirements

--- a/examples/goes-utah-satellite.ipynb
+++ b/examples/goes-utah-satellite.ipynb
@@ -1,0 +1,609 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# GOES-18 Satellite Imagery: Utah Region\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/national-data-platform/ep-tutorials/blob/main/examples/goes-utah-satellite.ipynb)\n",
+    "\n",
+    "This example demonstrates an end-to-end workflow using NDP-EP:\n",
+    "\n",
+    "1. **Register** external GOES-18 data (from AWS) in the NDP-EP catalog\n",
+    "2. **Download** satellite imagery from the registered source\n",
+    "3. **Process** and crop to Utah region\n",
+    "4. **Upload** processed data to local S3 storage\n",
+    "5. **Register** the processed dataset in NDP-EP\n",
+    "6. **Visualize** with interactive maps\n",
+    "\n",
+    "## Prerequisites\n",
+    "\n",
+    "- Access to an NDP-EP API instance\n",
+    "- Valid authentication token"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Install required packages:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install ndp-ep xarray netCDF4 pyproj folium numpy requests -q"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import xarray as xr\n",
+    "import requests\n",
+    "import folium\n",
+    "from folium.plugins import ImageOverlay\n",
+    "from pyproj import CRS, Transformer\n",
+    "from ndp_ep import Client\n",
+    "import tempfile\n",
+    "import os"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Configuration\n",
+    "\n",
+    "Set your NDP-EP API endpoint and token:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# NDP-EP Configuration\n",
+    "API_URL = \"http://localhost:8002\"  # Change to your API endpoint\n",
+    "TOKEN = \"your-token-here\"          # Change to your token\n",
+    "\n",
+    "# Initialize client\n",
+    "client = Client(base_url=API_URL, token=TOKEN)\n",
+    "\n",
+    "# Verify connection\n",
+    "status = client.get_system_status()\n",
+    "print(f\"Connected to: {status['ep_name']}\")\n",
+    "print(f\"API Version: {status['api_version']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 1: Register GOES-18 External Data Source\n",
+    "\n",
+    "NOAA provides GOES-18 satellite data publicly on AWS S3. We'll register this external data source in our NDP-EP catalog."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# GOES-18 data on AWS (publicly accessible)\n",
+    "GOES_AWS_BUCKET = \"noaa-goes18\"\n",
+    "GOES_PRODUCT = \"ABI-L2-MCMIPC\"  # Multi-band Cloud/Moisture Imagery - CONUS\n",
+    "\n",
+    "# Sample file from November 25, 2024 at 18:00 UTC\n",
+    "GOES_FILE_KEY = \"ABI-L2-MCMIPC/2024/330/18/OR_ABI-L2-MCMIPC-M6_G18_s20243301801170_e20243301803543_c20243301804085.nc\"\n",
+    "GOES_FILE_URL = f\"https://{GOES_AWS_BUCKET}.s3.amazonaws.com/{GOES_FILE_KEY}\"\n",
+    "\n",
+    "print(f\"GOES-18 file URL: {GOES_FILE_URL}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Register the external GOES data source in NDP-EP catalog\n",
+    "# Note: This registers metadata pointing to the AWS location\n",
+    "\n",
+    "try:\n",
+    "    result = client.register_url({\n",
+    "        \"resource_name\": \"goes18-conus-sample\",\n",
+    "        \"resource_title\": \"GOES-18 CONUS Multi-band Imagery Sample\",\n",
+    "        \"owner_org\": \"noaa-demo\",\n",
+    "        \"resource_url\": GOES_FILE_URL,\n",
+    "        \"file_type\": \"NetCDF\",\n",
+    "        \"notes\": \"GOES-18 ABI L2 Cloud and Moisture Imagery Product (MCMIPC) for CONUS region. Source: NOAA AWS Open Data.\"\n",
+    "    })\n",
+    "    print(f\"Registered external dataset: {result}\")\n",
+    "except Exception as e:\n",
+    "    print(f\"Dataset may already exist or error: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 2: Search and Download the Data\n",
+    "\n",
+    "Now we can discover this data through the NDP-EP catalog and download it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Search for GOES data in the catalog\n",
+    "datasets = client.search_datasets(terms=[\"goes18\"])\n",
+    "print(f\"Found {len(datasets)} GOES datasets\")\n",
+    "\n",
+    "for ds in datasets[:5]:\n",
+    "    print(f\"  - {ds['name']}: {ds.get('title', 'N/A')}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Download the GOES file\n",
+    "print(\"Downloading GOES-18 file (~55MB)...\")\n",
+    "\n",
+    "temp_dir = tempfile.mkdtemp()\n",
+    "goes_file = os.path.join(temp_dir, \"goes18_conus.nc\")\n",
+    "\n",
+    "response = requests.get(GOES_FILE_URL, stream=True)\n",
+    "total_size = int(response.headers.get('content-length', 0))\n",
+    "\n",
+    "with open(goes_file, 'wb') as f:\n",
+    "    downloaded = 0\n",
+    "    for chunk in response.iter_content(chunk_size=8192):\n",
+    "        f.write(chunk)\n",
+    "        downloaded += len(chunk)\n",
+    "        if total_size:\n",
+    "            print(f\"\\rDownloading: {downloaded/1e6:.1f}/{total_size/1e6:.1f} MB\", end=\"\")\n",
+    "\n",
+    "print(f\"\\nDownloaded to: {goes_file}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 3: Process and Crop to Utah Region\n",
+    "\n",
+    "We'll extract the visible band (CMI_C02 - Red) and crop to Utah's boundaries."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Utah geographic bounds\n",
+    "UTAH_BOUNDS = {\n",
+    "    'lat_min': 37.0,\n",
+    "    'lat_max': 42.0,\n",
+    "    'lon_min': -114.0,\n",
+    "    'lon_max': -109.0\n",
+    "}\n",
+    "\n",
+    "print(f\"Utah bounds: {UTAH_BOUNDS}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Open the GOES file\n",
+    "ds = xr.open_dataset(goes_file)\n",
+    "\n",
+    "# Get projection parameters\n",
+    "proj = ds['goes_imager_projection']\n",
+    "h = proj.attrs['perspective_point_height']\n",
+    "lon_0 = proj.attrs['longitude_of_projection_origin']\n",
+    "sweep = proj.attrs.get('sweep_angle_axis', 'x')\n",
+    "\n",
+    "print(f\"Satellite: GOES-18 at {lon_0}°W\")\n",
+    "print(f\"Perspective height: {h/1e6:.1f} km\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create coordinate transformation\n",
+    "goes_crs = CRS.from_cf({\n",
+    "    'grid_mapping_name': 'geostationary',\n",
+    "    'longitude_of_projection_origin': lon_0,\n",
+    "    'perspective_point_height': h,\n",
+    "    'sweep_angle_axis': sweep,\n",
+    "    'semi_major_axis': proj.attrs['semi_major_axis'],\n",
+    "    'semi_minor_axis': proj.attrs['semi_minor_axis'],\n",
+    "})\n",
+    "\n",
+    "transformer = Transformer.from_crs(goes_crs, \"EPSG:4326\", always_xy=True)\n",
+    "\n",
+    "# Get coordinates\n",
+    "x = ds['x'].values * h\n",
+    "y = ds['y'].values * h\n",
+    "xx, yy = np.meshgrid(x, y)\n",
+    "\n",
+    "# Transform to lat/lon\n",
+    "lon, lat = transformer.transform(xx, yy)\n",
+    "\n",
+    "print(f\"Image coverage:\")\n",
+    "print(f\"  Latitude: {np.nanmin(lat):.1f}° to {np.nanmax(lat):.1f}°\")\n",
+    "print(f\"  Longitude: {np.nanmin(lon):.1f}° to {np.nanmax(lon):.1f}°\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Find Utah region indices\n",
+    "utah_mask = (\n",
+    "    (lat >= UTAH_BOUNDS['lat_min']) & \n",
+    "    (lat <= UTAH_BOUNDS['lat_max']) & \n",
+    "    (lon >= UTAH_BOUNDS['lon_min']) & \n",
+    "    (lon <= UTAH_BOUNDS['lon_max'])\n",
+    ")\n",
+    "\n",
+    "utah_indices = np.where(utah_mask)\n",
+    "y_min, y_max = utah_indices[0].min(), utah_indices[0].max()\n",
+    "x_min, x_max = utah_indices[1].min(), utah_indices[1].max()\n",
+    "\n",
+    "print(f\"Utah region: {y_max-y_min} x {x_max-x_min} pixels\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Extract Utah subset - using visible band (C02 - Red, 0.64 µm)\n",
+    "cmi_full = ds['CMI_C02'].values\n",
+    "cmi_utah = cmi_full[y_min:y_max, x_min:x_max]\n",
+    "lat_utah = lat[y_min:y_max, x_min:x_max]\n",
+    "lon_utah = lon[y_min:y_max, x_min:x_max]\n",
+    "\n",
+    "print(f\"Utah subset shape: {cmi_utah.shape}\")\n",
+    "print(f\"Reflectance range: {np.nanmin(cmi_utah):.3f} to {np.nanmax(cmi_utah):.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Save Utah subset as NetCDF\n",
+    "utah_file = os.path.join(temp_dir, \"goes18_utah.nc\")\n",
+    "\n",
+    "utah_ds = xr.Dataset({\n",
+    "    'reflectance': (['y', 'x'], cmi_utah),\n",
+    "    'latitude': (['y', 'x'], lat_utah),\n",
+    "    'longitude': (['y', 'x'], lon_utah),\n",
+    "})\n",
+    "\n",
+    "utah_ds.attrs = {\n",
+    "    'title': 'GOES-18 Utah Region Subset',\n",
+    "    'source': 'NOAA GOES-18 ABI L2 MCMIPC',\n",
+    "    'band': 'C02 (Red, 0.64 µm)',\n",
+    "    'processing': 'Cropped to Utah bounds',\n",
+    "    'bounds': str(UTAH_BOUNDS),\n",
+    "}\n",
+    "\n",
+    "utah_ds.to_netcdf(utah_file)\n",
+    "print(f\"Saved Utah subset: {utah_file}\")\n",
+    "print(f\"File size: {os.path.getsize(utah_file)/1e6:.2f} MB\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 4: Upload to Local S3 Storage\n",
+    "\n",
+    "Upload the processed Utah subset to the NDP-EP S3 storage."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a bucket for satellite data\n",
+    "BUCKET_NAME = \"satellite-data\"\n",
+    "\n",
+    "try:\n",
+    "    result = client.create_bucket(BUCKET_NAME)\n",
+    "    print(f\"Created bucket: {result}\")\n",
+    "except Exception as e:\n",
+    "    print(f\"Bucket may already exist: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Upload the Utah NetCDF file\n",
+    "with open(utah_file, 'rb') as f:\n",
+    "    utah_data = f.read()\n",
+    "\n",
+    "result = client.upload_object(\n",
+    "    bucket_name=BUCKET_NAME,\n",
+    "    object_key=\"goes18/utah/goes18_utah_20241125_1800.nc\",\n",
+    "    file_data=utah_data,\n",
+    "    content_type=\"application/x-netcdf\"\n",
+    ")\n",
+    "\n",
+    "print(f\"Uploaded: {result}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Generate a shareable URL\n",
+    "url_result = client.generate_presigned_download_url(\n",
+    "    bucket_name=BUCKET_NAME,\n",
+    "    object_key=\"goes18/utah/goes18_utah_20241125_1800.nc\",\n",
+    "    expiration=86400  # 24 hours\n",
+    ")\n",
+    "\n",
+    "print(f\"Shareable URL (valid 24h): {url_result['url'][:80]}...\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 5: Register Processed Dataset\n",
+    "\n",
+    "Register the processed Utah dataset in the NDP-EP catalog."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Register the Utah subset as a new S3 resource\n",
+    "try:\n",
+    "    result = client.register_s3_link({\n",
+    "        \"resource_name\": \"goes18-utah-subset\",\n",
+    "        \"resource_title\": \"GOES-18 Utah Region Satellite Imagery\",\n",
+    "        \"owner_org\": \"noaa-demo\",\n",
+    "        \"s3_bucket\": BUCKET_NAME,\n",
+    "        \"s3_key\": \"goes18/utah/goes18_utah_20241125_1800.nc\",\n",
+    "        \"notes\": \"Processed GOES-18 visible band imagery cropped to Utah region (37-42°N, 109-114°W).\"\n",
+    "    })\n",
+    "    print(f\"Registered processed dataset: {result}\")\n",
+    "except Exception as e:\n",
+    "    print(f\"Registration result: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 6: Search and Verify\n",
+    "\n",
+    "Search for Utah data in the catalog."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Search for Utah datasets\n",
+    "utah_datasets = client.search_datasets(terms=[\"utah\"])\n",
+    "print(f\"Found {len(utah_datasets)} Utah datasets:\")\n",
+    "\n",
+    "for ds in utah_datasets:\n",
+    "    print(f\"  - {ds['name']}: {ds.get('title', 'N/A')}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 7: Interactive Visualization with Folium\n",
+    "\n",
+    "Create an interactive map showing the satellite imagery over Utah."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Normalize reflectance to 0-255 for visualization\n",
+    "cmi_normalized = np.clip(cmi_utah, 0, 1)\n",
+    "cmi_normalized = np.nan_to_num(cmi_normalized, nan=0)\n",
+    "\n",
+    "# Apply gamma correction for better visibility\n",
+    "gamma = 0.5\n",
+    "cmi_gamma = np.power(cmi_normalized, gamma)\n",
+    "\n",
+    "# Convert to RGB (grayscale)\n",
+    "cmi_uint8 = (cmi_gamma * 255).astype(np.uint8)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Save as PNG for Folium overlay\n",
+    "from PIL import Image\n",
+    "\n",
+    "# Create grayscale image\n",
+    "img = Image.fromarray(cmi_uint8, mode='L')\n",
+    "png_file = os.path.join(temp_dir, \"utah_satellite.png\")\n",
+    "img.save(png_file)\n",
+    "\n",
+    "print(f\"Saved visualization: {png_file}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get actual bounds from the data\n",
+    "bounds = [\n",
+    "    [np.nanmin(lat_utah), np.nanmin(lon_utah)],  # Southwest\n",
+    "    [np.nanmax(lat_utah), np.nanmax(lon_utah)]   # Northeast\n",
+    "]\n",
+    "\n",
+    "print(f\"Image bounds: {bounds}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create interactive map\n",
+    "import base64\n",
+    "\n",
+    "# Center on Utah\n",
+    "utah_center = [39.5, -111.5]\n",
+    "\n",
+    "# Create map\n",
+    "m = folium.Map(\n",
+    "    location=utah_center,\n",
+    "    zoom_start=7,\n",
+    "    tiles='OpenStreetMap'\n",
+    ")\n",
+    "\n",
+    "# Read image as base64\n",
+    "with open(png_file, 'rb') as f:\n",
+    "    img_data = base64.b64encode(f.read()).decode()\n",
+    "\n",
+    "# Add satellite image overlay\n",
+    "img_overlay = folium.raster_layers.ImageOverlay(\n",
+    "    image=f\"data:image/png;base64,{img_data}\",\n",
+    "    bounds=bounds,\n",
+    "    opacity=0.7,\n",
+    "    name=\"GOES-18 Visible Band\"\n",
+    ")\n",
+    "img_overlay.add_to(m)\n",
+    "\n",
+    "# Add layer control\n",
+    "folium.LayerControl().add_to(m)\n",
+    "\n",
+    "# Add title\n",
+    "title_html = '''\n",
+    "<div style=\"position: fixed; \n",
+    "            top: 10px; left: 50px; width: 300px;\n",
+    "            background-color: white; padding: 10px;\n",
+    "            border-radius: 5px; box-shadow: 2px 2px 5px gray;\">\n",
+    "    <b>GOES-18 Satellite Imagery</b><br>\n",
+    "    Utah Region - Visible Band (0.64 µm)<br>\n",
+    "    <small>November 25, 2024 18:00 UTC</small>\n",
+    "</div>\n",
+    "'''\n",
+    "m.get_root().html.add_child(folium.Element(title_html))\n",
+    "\n",
+    "# Display map\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cleanup\n",
+    "\n",
+    "Optionally clean up the temporary files and registered datasets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Close the dataset\n",
+    "ds.close()\n",
+    "\n",
+    "# Uncomment to clean up:\n",
+    "# client.delete_object(BUCKET_NAME, \"goes18/utah/goes18_utah_20241125_1800.nc\")\n",
+    "# client.delete_bucket(BUCKET_NAME)\n",
+    "\n",
+    "print(\"Done!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "In this example, we demonstrated:\n",
+    "\n",
+    "1. **Data Discovery**: Registering external data sources (NOAA AWS) in NDP-EP\n",
+    "2. **Data Processing**: Downloading and cropping satellite imagery to a region of interest\n",
+    "3. **Data Management**: Uploading processed data to local S3 storage\n",
+    "4. **Cataloging**: Registering derived datasets for discovery\n",
+    "5. **Visualization**: Creating interactive maps with Folium\n",
+    "\n",
+    "This workflow can be adapted for other satellite products, regions, or time series analysis."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary

- Complete Jupyter notebook demonstrating end-to-end NDP-EP workflow with GOES-18 satellite data
- Includes "Open in Colab" badge for easy online execution
- Interactive Folium map visualization (instead of static matplotlib plots)
- Updated examples README with running instructions

## Workflow Demonstrated

1. Register external GOES-18 data (from AWS) in NDP-EP catalog
2. Download satellite imagery from registered source
3. Process and crop to Utah region (37-42°N, 109-114°W)
4. Upload processed data to local S3 storage
5. Register the processed dataset in NDP-EP
6. Visualize with interactive Folium maps

## Test Plan

- [ ] Verify Colab badge opens notebook correctly
- [ ] Test notebook execution with local NDP-EP instance
- [ ] Confirm GOES file downloads from AWS
- [ ] Verify Utah region cropping works correctly

Closes #13